### PR TITLE
코드 형식 지정 및 린팅을 위한 pre-commit 훅 구성 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ db.sqlite3
 .DS_Store
 */migrations/
 .initialize_django_env/
-.pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort (python)
+        args: ["--profile", "black", "-l", "120", "--skip-gitignore"]
+
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black
+        args: [--line-length, "120", --skip-magic-trailing-comma]
+
+  - repo: https://github.com/pycqa/autoflake
+    rev: v1.4
+    hooks:
+      - id: autoflake
+        args: 
+          - --in-place
+          - --remove-all-unused-imports
+          - --remove-unused-variables
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8
+        args:
+          ["--max-line-length", "120", "--extend-ignore", "E203, F403, F405", "--show-source",]


### PR DESCRIPTION
## 코드 변경 이유  
코드 품질을 향상하고 프로젝트 전반의 일관성을 유지하기 위해, 자동화된 형식 지정 및 린팅 도구를 pre-commit 훅으로 통합하여, 모든 커밋이 코드 표준을 준수하고 이를 통해 스타일 위반 가능성을 줄이고, 가독성을 향상시키기 위함

<br>

## 구현 사항  
- isort
- black
- autoflake
- flake8

<br>

## 발견 위험/장애  
- develop 머지 후 pre-commit run --all-files 를 통해 전체 프로젝트에 적용 시켜주기